### PR TITLE
Fixes #255 : migration script nip to id

### DIFF
--- a/simaya/controller/admin.js
+++ b/simaya/controller/admin.js
@@ -193,7 +193,7 @@ module.exports = function (app) {
         res.redirect("/")
       }
     }
-    var isPolitical = (req.body.nip === "000000000000000000");
+    var isPolitical = (req.body.id === "000000000000000000");
     role.list(function(roleList) {
       vals.roleList = roleList;
       if (typeof(req.body) === "object" && Object.keys(req.body).length != 0) {
@@ -201,23 +201,23 @@ module.exports = function (app) {
         vals.profile = req.body.profile;
 
         if (parseInt(req.body.profile.echelon) != 0) {
-          if (isLocalAdmin && req.body.profile.nip.length != 18 && !isPolitical) {
+          if (isLocalAdmin && req.body.profile.id.length != 18 && !isPolitical) {
             vals.unsuccessful = true;
             vals.form = true;
             vals.messages = vals.messages || []
-            vals.messages.push({message: 'NIP "' + req.body.profile.nip + '" tidak sesuai. NIP harus 18 angka.'})
+            vals.messages.push({message: 'NIP "' + req.body.profile.id + '" tidak sesuai. NIP harus 18 angka.'})
             return utils.render(req, res, 'admin-new-user', vals, 'base-admin-authenticated');
           }
         }
 
-        user.list({ search: {'profile.nip': req.body.profile.nip}}, function (r) {
+        user.list({ search: {'profile.id': req.body.profile.id}}, function (r) {
           if (isLocalAdmin && r[0] != null && parseInt(req.body.profile.echelon) != 0) {
-            if (r[0].profile.nip == req.body.profile.nip && r[0].username != req.body.username && !isPolitical) {
+            if (r[0].profile.id == req.body.profile.id && r[0].username != req.body.username && !isPolitical) {
               vals.unsuccessful = true;
               vals.existNip = true;
               vals.form = true;
               vals.messages = vals.messages || []
-              vals.messages.push({message: 'NIP "' + req.body.profile.nip + '" sudah ada'})
+              vals.messages.push({message: 'NIP "' + req.body.profile.id + '" sudah ada'})
               return utils.render(req, res, 'admin-new-user', vals, 'base-admin-authenticated');
             } else {
               newUserReal(req, res, vals);
@@ -323,7 +323,7 @@ module.exports = function (app) {
 
 
       if (isLocalAdmin && parseInt(req.body.profile.echelon) != 0) {
-        if (req.body.profile && req.body.profile.nip && req.body.profile.nip.length != 18) {
+        if (req.body.profile && req.body.profile.id && req.body.profile.id.length != 18) {
           vals.unsuccessful = true;
           vals.invalidNip = true;
           utils.render(req, res, 'admin-edit-user', vals, 'base-admin-authenticated');
@@ -331,9 +331,9 @@ module.exports = function (app) {
         }
       }
 
-      user.list({ search: {'profile.nip': req.body.profile.nip}}, function (r) {
+      user.list({ search: {'profile.id': req.body.profile.id}}, function (r) {
         if (isLocalAdmin && r[0] != null && parseInt(req.body.profile.echelon) != 0) {
-          if (r[0].profile.nip == req.body.profile.nip && r[0].username != req.body.username) {
+          if (r[0].profile.id == req.body.profile.id && r[0].username != req.body.username) {
             vals.unsuccessful = true;
             vals.existNip = true;
             utils.render(req, res, 'admin-edit-user', vals, 'base-admin-authenticated');
@@ -435,7 +435,7 @@ module.exports = function (app) {
       search.search["$or"] = [
         { "username": { $regex: req.query.search }},
         { "profile.fullName": { $regex: req.query.search }},
-        { "profile.nip": { $regex: req.query.search }},
+        { "profile.id": { $regex: req.query.search }},
         { "profile.title": { $regex: req.query.search, $options: "i" } },
       ];
     }

--- a/simaya/controller/profile.js
+++ b/simaya/controller/profile.js
@@ -393,7 +393,7 @@ module.exports = function(app) {
             }
           });
         } else {
-          renderDefaultAvatar(base64, getGender(item[0].profile.nip), req, res);
+          renderDefaultAvatar(base64, getGender(item[0].profile.id), req, res);
         }
       } else {
         renderDefaultAvatar(base64, "male", req, res);

--- a/static/js/nip-checker.js
+++ b/static/js/nip-checker.js
@@ -1,5 +1,5 @@
 $(document).ready(function() {
-  $('input[name="profile[nip]"]').keydown(function(event) {
+  $('input[name="profile[id]"]').keydown(function(event) {
     // Allow: backspace, delete, tab, escape, and enter
     if ( event.keyCode == 46 || event.keyCode == 8 || event.keyCode == 9 || event.keyCode == 27 || event.keyCode == 13 || 
       // Allow: Ctrl+A
@@ -15,11 +15,11 @@ $(document).ready(function() {
       }   
     }
   });
-  $('input[name="profile[nip]"]').keyup(function(event) {
+  $('input[name="profile[id]"]').keyup(function(event) {
     if ( event.which == 13 ) {
       event.preventDefault();
     }
-    var counter = $('input[name="profile[nip]"]').val().length;
+    var counter = $('input[name="profile[id]"]').val().length;
     console.log(counter);
     if (counter > 18 || counter < 18) {
       $('#nip-control').addClass('error');

--- a/tools/initial-data/role
+++ b/tools/initial-data/role
@@ -9,3 +9,4 @@
 { "roleName" : "plh", "roleDescription" : "Buat Assign Plh", "_id" : { "$oid" : "50f6247cd421af3e0100001d" }, "created_at" : { "$date" : 1358308476998 } }
 { "roleName" : "agenda", "roleDescription" : "Modul Agenda", "_id" : { "$oid" : "50fca592f4403ad60e000008" }, "created_at" : { "$date" : 1358734738257 } }
 { "roleName" : "sender", "roleDescription" : "Satuan Kerja", "_id" : { "$oid" : "5225885de954a0660e000010" }, "created_at" : { "$date" : 1378191453333 } }
+

--- a/tools/initial-data/userCategory
+++ b/tools/initial-data/userCategory
@@ -1,0 +1,2 @@
+{ "categoryName" : "PNS", "categoryDesc" : "Pegawai Negeri Sipil", "categoryId" : "NIP", "idLength" : "18", "_id" : ObjectId("54986ce0f943bf04145d6869"), "created_at" : ISODate("2014-12-22T19:11:28.536Z") }
+

--- a/tools/migrate-nip-id.js
+++ b/tools/migrate-nip-id.js
@@ -1,0 +1,47 @@
+// This script migrates profile.nip to profile.id
+
+var settings = require('../settings.js')
+
+var app = {
+  db: function(modelName) {
+    return settings.model(settings.db, modelName);
+  }
+  , ObjectID: settings.ObjectID
+  , validator: settings.validator
+}
+var db = app.db("user")
+var spinner = ["/", "-", "|", "\\"];
+
+var saved = 0;
+var mod = function(index, data) {
+  if (index == data.length) {
+    console.log("Saved: ", saved, "of total", data.length);
+    process.exit();
+    return;
+  }
+  db.findOne({_id: data[index]._id}, function(e, item) {
+    process.stdout.write(spinner[(index % 4)] + " -> " + index + "/" + data.length + "\r");
+    var save = false;
+    if (item.profile.nip) {
+      item.profile.id = item.profile.nip;
+      item.profile.category = "PNS";
+      delete item.profile.nip;
+      save = true;
+    } 
+    if (save) {
+      saved ++;
+      db.save(item, function() {
+        mod(index + 1, data);
+      });
+    } else {
+      mod(index + 1, data);
+    }
+  });
+}
+
+console.log("Standing by...");
+settings.db.open(function(){
+  db.findArray({}, {_id:1,date:1}, function(e, c) {
+    mod(0, c);
+  })
+});

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -6,6 +6,7 @@ echo "Setting up initial data with DB $DB"
 node tools/init-admin.js
 mkdir uploads
 mongoimport -d $DB -c role --drop < tools/initial-data/role
+mongoimport -d $DB -c userCategory --drop < tools/initial-data/userCategory
 cd ../..
 if [ -d node_modules/simaya ];then
     rm -f simaya

--- a/views/admin-edit-user.html
+++ b/views/admin-edit-user.html
@@ -165,9 +165,9 @@
                   </div>
                 </div>
              	<div class="control-group" id="nip-control">
-            		<label class="control-label" for="profile[nip]">NIP</label>
+            		<label class="control-label" for="profile[id]">NIP</label>
             		<div class="controls">
-            				<input class="span6" id="nip-input" type=text name="profile[nip]" value="{{profile.nip}}" />
+            				<input class="span6" id="nip-input" type=text name="profile[id]" value="{{profile.id}}" />
             				<span class="help-inline" id="nip-help-inline"></span>
             		</div>
             	</div>

--- a/views/admin-new-user.html
+++ b/views/admin-new-user.html
@@ -170,9 +170,9 @@
           </div>
 
           <div class="control-group" id="nip-control">
-            <label class="control-label" for="profile[nip]">NIP</label>
+            <label class="control-label" for="profile[id]">NIP</label>
             <div class="controls">
-              <input class="span6" id="nip-input" type=text name="profile[nip]" value="{{profile.nip}}" />
+              <input class="span6" id="nip-input" type=text name="profile[id]" value="{{profile.id}}" />
               <span class="help-inline" id="nip-help-inline"></span>
             </div>
           </div>

--- a/views/profile-view.html
+++ b/views/profile-view.html
@@ -29,7 +29,7 @@ Pengguna tidak dikenal.
 			</tr>
 			<tr>
 				<td class="span2">NIP</td>
-				<td>{{profile.nip}}</td>
+				<td>{{profile.id}}</td>
 			</tr>
 			<tr>
 				<td class="span2">Surel</td>

--- a/views/profile.html
+++ b/views/profile.html
@@ -43,7 +43,7 @@
     <div class="control-group">
       <label class="control-label" for="idNumber">NIP</label>
       <div class="controls">
-        <span class="span3 uneditable-input">{{profile.nip}}</span>
+        <span class="span3 uneditable-input">{{profile.id}}</span>
       </div>
     </div>
     <div class="control-group">


### PR DESCRIPTION
1. backup db yang ingin dimigrasi, buat jaga-jaga. misal aslinya "simayamaster"

```
> db.copyDatabase("simayamaster","simayamaster_bak")
```
1. jalankan skrip migrasi

```
...simaya/tools$ DB=simayamaster node migrate-nip-id.js
```
1. tertib. selesai.

Yang dikerjakan skrip ini :
- pada user, mengganti nip dengan id dengan nilai yang sama
- pada user, menambahkan key "category" dengan nilai objectid dari "PNS".

catatan : 
- jumlah user mungkin perlu dipangkas agar cepat selesai
- indikator berhasil adalah, key "profile.nip" berhasil diganti menjadi "profile.id" dengan nilai yang sama
  sebelum migrasi, mungkin perlu diambil sampel, sebagai pembanding, misal : 

```
> db.user.findOne({username:"namapengguna"})
```

jalankan sebelum dan setelah migrasi, bandingkan.

Dari yang seperti ini : 

```
{
...
    "profile" : {
        "fullName" : "Contoh",
        "organization" : "KPU",
        "title" : "Kabag",
        "echelon" : "3a",
        "class" : "4a",
        "nip" : "135485654789542102",
    },
...
```

Menjadi seperti ini :

```
{
...
    "profile" : {
        "fullName" : "Contoh",
        "organization" : "KPU",
        "title" : "Kabag",
        "echelon" : "3a",
        "class" : "4a",
        "id" : "135485654789542102",
        "category" : "PNS"
    },
...
```
