### PR TITLE
Fixes #291 return a bundle of uploaded files

### DIFF
--- a/simaya/controller/letter.js
+++ b/simaya/controller/letter.js
@@ -2318,6 +2318,7 @@ Letter = module.exports = function(app) {
         }
       }
       // sends the bundle!
+      res.send(bundle);
     })
   }
 


### PR DESCRIPTION
This line has been accidentally removed in the previous commit (98f4bd9). I apologize for this error.
